### PR TITLE
Added stack instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ $ cabal v2-run exe:ficktoberfest <token-file>
 ```
 
 ### Stack
-
-TBD
-
-<!-- TODO(#6): Stack Quick Start section is not documented -->
+```console
+$ stack run -- <token-file>
+```
 
 ## Token File
 

--- a/ficktoberfest.cabal
+++ b/ficktoberfest.cabal
@@ -30,16 +30,16 @@ executable ficktoberfest
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.12 && <4.13
+  build-depends:       base >=4.14.3 && <4.15
                      , text >=1.2.4 && <1.3
-                     , bytestring >=0.10.8 && <0.11
-                     , aeson >=1.4.6 && <1.5
-                     , http-types >=0.12 && <0.13
+                     , bytestring >=0.10.12 && <0.11
+                     , aeson >=1.5.6 && <1.6
+                     , http-types >=0.12.3 && <0.13
                      , http-client >=0.6.4 && <0.7
                      , http-client-tls >=0.3.5 && <0.4
-                     , time >=1.8.0 && <1.9
-                     , unordered-containers >=0.2.8.0 && <0.3
-                     , vector ==0.12.1.2
+                     , time >=1.9.3 && <1.10
+                     , unordered-containers >=0.2.14.0 && <0.3
+                     , vector >=0.12.3 && <0.13
 
   -- hs-source-dirs:
   default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,26 +1,16 @@
-resolver: lts-14.27
-compiler: ghc-8.6.5
+resolver: lts-18.14
+compiler: ghc-8.10.7
 
 packages:
 - .
 
 extra-deps:
-- text-1.2.4.0
-- bytestring-0.10.12.0
-- aeson-1.4.6.0
-- http-types-0.12
-- http-client-0.6.4
-- http-client-tls-0.3.5
-- time-1.8.0.4
-- directory-1.3.6.1
-- process-1.6.10.0
-- binary-0.8.8.0
-- array-0.5.4.0
-- containers-0.6.4.1
-- deepseq-1.4.4.0
-- filepath-1.4.2.1
-- mtl-2.2.2
-- parsec-3.1.14.0
-- stm-2.5.0.0
-- transformers-0.5.6.2
-- unix-2.7.2.2
+  - text-1.2.4.1
+  - bytestring-0.10.12.0
+  - aeson-1.5.6.0
+  - http-types-0.12.3
+  - http-client-0.6.4.1
+  - http-client-tls-0.3.5.3
+  - time-1.9.3
+  - unordered-containers-0.2.14.0
+  - vector-0.12.3.1


### PR DESCRIPTION
Closes #6

I coudn't find the `lts` in hackage you were using. [`lts-14.27`](https://www.stackage.org/lts-14.27) for example has `text-1.2.3.1` not `text-1.2.4.0` as the `stack.yaml` mentioned 🤷.