### PR TITLE
Parse an optional github owner

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -199,13 +199,18 @@ resultToEither :: Result a -> Either String a
 resultToEither (Success x) = Right x
 resultToEither (Error s) = Left s
 
-mainWithArgs :: [String] -> IO ()
-mainWithArgs (tokenFile:_) = do
-  github <- newGithub tokenFile
+data Args = Args { argTokenFile :: String, argOwner :: Owner }
+
+parseArgs :: [String] -> Args
+parseArgs [] = error "Usage: ficktoberfest <tokenFile> [owner]"
+parseArgs [tokenFile'] = Args tokenFile' (Owner "tsoding")
+parseArgs (tokenFile:owner:_) = Args tokenFile (Owner $ T.pack owner)
+
+mainWithArgs :: Args -> IO ()
+mainWithArgs args = do
+  github <- newGithub $ argTokenFile args
   putStrLn "Waiting for Pull Requests..."
-  -- TODO(#7): The polling target is hardcoded
-  pollLoop github (Owner "tsoding") Nothing Nothing
-mainWithArgs _ = error "Usage: ficktoberfest <tokenFile>"
+  pollLoop github (argOwner args) Nothing Nothing
 
 main :: IO ()
-main = getArgs >>= mainWithArgs
+main = getArgs >>= mainWithArgs . parseArgs

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple Haskell tool that silently marks all of the new PRs it receives via not
 
 ```console
 $ cabal v2-build
-$ cabal v2-run exe:ficktoberfest <token-file>
+$ cabal v2-run exe:ficktoberfest <token-file> [owner]
 ```
 
 ### Stack
@@ -16,6 +16,8 @@ $ cabal v2-run exe:ficktoberfest <token-file>
 TBD
 
 <!-- TODO(#6): Stack Quick Start section is not documented -->
+
+The owner is "tsoding" unless otherwise specified.
 
 ## Token File
 


### PR DESCRIPTION
Closes #7 .

If https://github.com/tsoding/ficktoberfest/pull/11 gets merged before; we should update the stack quickstart with the `[owner]` optional arg.